### PR TITLE
Support Rails `4.2` and above

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Within Named Scope
 
 A simple gem for drying up checking if an ActiveRecord instance is within a named scope.
 
-Support for Rails 3.2+ and 4.0+
+Support for Rails and 4.2+
 
 Usage
 ---------------------

--- a/lib/within_named_scope.rb
+++ b/lib/within_named_scope.rb
@@ -5,7 +5,7 @@ module WithinNamedScope
   end
 
   def in_scope?(scope)
-    !!self.class.send(scope.to_sym).exists?(self)
+    !!self.class.send(scope.to_sym).exists?(self.id)
   end
 
   module ClassMethods

--- a/within_named_scope.gemspec
+++ b/within_named_scope.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "> 3.2.0"
+  s.add_dependency "rails", ">= 4.2.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Passing an `ActiveRecord` object to `exists?` was deprecated in [2014][], which was version `4.2.0`.

This commit ensures we pass the `id` of the object instead.

[2014]: https://github.com/rails/rails/commit/d92ae6ccca3bcfd73546d612efaea011270bd270